### PR TITLE
Added Visual Studio Code devcontainer definition for 1.10.x examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Jolie Examples
 Examples used for Jolie tutorials and other explanations
+
+## Visual Studio Code Dev Containers (1.10.x only)
+A devcontainer file is provided to give quick access to the examples.
+
+The main configuration points to the 1.10.5 version image, if you want to use the development image just change the __image__ property in _.devcontainer/devcontainer.json_ (as in _edge-devcontainer.json_).
+
+To open the development container just move to the _v1.10.x_ directory, open VS Code, type __CTRL+Shift+P__ and select "Remote Containers: Reopen in Container".

--- a/v1.10.x/.devcontainer/devcontainer.json
+++ b/v1.10.x/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "jolielang/jolie:1.10.5",
+  "extensions": [
+    "jolie.vscode-jolie"
+  ]
+}

--- a/v1.10.x/.devcontainer/edge-devcontainer.json
+++ b/v1.10.x/.devcontainer/edge-devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "jolielang/jolie:edge",
+  "extensions": [
+    "jolie.vscode-jolie"
+  ]
+}


### PR DESCRIPTION
Added a devcontainer definition to allow development in a Docker container within VS Code. 
Only 1.10.x is supported (latest stable 1.10.5 and edge image shown as examples).
If interested to allow the same for older examples, 1.9.1 image should be rebuilt (getting an error message about unsupported Alpine version).